### PR TITLE
Ember-changeset Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ You can use `testSelector` in your acceptance tests:
 * `find(testSelector('do-feedback', 'lastName'));`
 * `find(testSelector('do-hint', 'lastName'));`
 
-You can also manually set the attributes:
+You can also manually set the attributes: 
 ```hbs
 {{field.do-control 'lastName' data-test-do-control='mySpecialSelector' }}
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Another icky part is customisation, which most other form builder addons fail sh
 ## Features
 
 * [Extremely](#css-customizations) [easy](#component-block-form) to [customize](#component-customizations), thanks to contextual components.
-* Bare minimum HTML with no CSS by default. Use it with any CSS framework you like.
+* Bare minimum HTML with no CSS by default. Use it with any CSS framework you like. 
 * Binds error and success classes (if found) on a field `focusOut` or just before `submit`. Works with [`ember-cp-validations`](https://github.com/offirgolan/ember-cp-validations) by default. [`ember-changeset-validations`](https://github.com/DockYard/ember-changeset-validations) works too with a small configuration tweak.
 * Uses [`ember-one-way-controls`](https://github.com/DockYard/ember-one-way-controls) under the hood for controls. But easily extensible with any control type.
 * [Fully compatible](#test-selectors) with [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors).
@@ -206,7 +206,7 @@ You can use `testSelector` in your acceptance tests:
 * `find(testSelector('do-feedback', 'lastName'));`
 * `find(testSelector('do-hint', 'lastName'));`
 
-You can also manually set the attributes: 
+You can also manually set the attributes:
 ```hbs
 {{field.do-control 'lastName' data-test-do-control='mySpecialSelector' }}
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Another icky part is customisation, which most other form builder addons fail sh
 ## Features
 
 * [Extremely](#css-customizations) [easy](#component-block-form) to [customize](#component-customizations), thanks to contextual components.
-* Bare minimum HTML with no CSS by default. Use it with any CSS framework you like. 
+* Bare minimum HTML with no CSS by default. Use it with any CSS framework you like.
 * Binds error and success classes (if found) on a field `focusOut` or just before `submit`. Works with [`ember-cp-validations`](https://github.com/offirgolan/ember-cp-validations) by default. [`ember-changeset-validations`](https://github.com/DockYard/ember-changeset-validations) works too with a small configuration tweak.
 * Uses [`ember-one-way-controls`](https://github.com/DockYard/ember-one-way-controls) under the hood for controls. But easily extensible with any control type.
 * [Fully compatible](#test-selectors) with [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors).
@@ -206,7 +206,7 @@ You can use `testSelector` in your acceptance tests:
 * `find(testSelector('do-feedback', 'lastName'));`
 * `find(testSelector('do-hint', 'lastName'));`
 
-You can also manually set the attributes: 
+You can also manually set the attributes:
 ```hbs
 {{field.do-control 'lastName' data-test-do-control='mySpecialSelector' }}
 ```
@@ -295,6 +295,19 @@ module.exports = function(environment) {
         controlSuccess: ['form-control-success'],
         controlError: ['form-control-danger']
       }
+    }
+  };
+};
+```
+
+To integrate with [`ember-changeset-validations`](https://github.com/DockYard/ember-changeset-validations) you should configure your errorsPath as follows:
+
+```js
+module.exports = function(environment) {
+  var ENV = {
+    'ember-do-forms': {
+      // The path to be read on the object for an errors array
+      errorsPath: 'error.{PROPERTY_NAME}.validation',
     }
   };
 };

--- a/addon/components/do-field.js
+++ b/addon/components/do-field.js
@@ -51,7 +51,7 @@ const DoLabelComponent = Component.extend({
   // Should work with cp-validations and changeset-validations as well
   errorMessage: computed('errors.[]', function() {
     let firstError = this.get('errors.0') || {};
-    if (typeof firstError === "string") {
+    if (typeof firstError === 'string') {
       return firstError;
     }
     return firstError.message || firstError.validation;

--- a/addon/components/do-field.js
+++ b/addon/components/do-field.js
@@ -51,6 +51,9 @@ const DoLabelComponent = Component.extend({
   // Should work with cp-validations and changeset-validations as well
   errorMessage: computed('errors.[]', function() {
     let firstError = this.get('errors.0') || {};
+    if (typeof firstError === "string") {
+      return firstError;
+    }
     return firstError.message || firstError.validation;
   }),
 

--- a/tests/integration/components/do-field-test.js
+++ b/tests/integration/components/do-field-test.js
@@ -265,6 +265,24 @@ test('it shows feedback when it has errors', function(assert) {
   assert.equal(this.$('.feedback-class').text().trim(), "can't be blank", 'has the correct feedback message');
 });
 
+test('it shows feedback when errorsPath is an array of strings', function(assert) {
+  assert.expect(3);
+  this.set('object.validations', {
+    attrs: { lastName: { errors: ["can't be blank"] } }
+  });
+
+  this.render(hbs`
+    {{#do-field 'lastName' object=object as |field|}}
+      {{field.do-control 'text' }}
+      {{field.do-feedback}}
+    {{/do-field}}
+  `);
+  assert.equal(this.$('.feedback-class').length, 0, "there's no feedback element initially");
+  this.$('div').trigger('focusout');
+  assert.equal(this.$('.feedback-class').length, 1, 'a feedback element is present');
+  assert.equal(this.$('.feedback-class').text().trim(), "can't be blank", 'has the correct feedback message');
+});
+
 test('the feedback can also read its message from the validation key', function(assert) {
   assert.expect(2);
   this.set('object.validations', {
@@ -446,4 +464,3 @@ test('data-test-* attributes are overriden when config.autoDataTestSelectors is 
   assert.equal(this.$('p').attr('data-test-do-feedback'), 'you', 'do-feedback has the data attribute');
   assert.equal(this.$('small').attr('data-test-do-hint'), 'up', 'do-hint has the data attribute');
 });
-


### PR DESCRIPTION
**Reason:**

I could not integrate ember-changeset with this addon based on existing documentation and possibly because of a bug. Please let me know if I’m missing something obvious.

**This pull request:**

- Allows the `do-field` `errorMessage` computed property to return a message if `errorsPath` returns an array of strings (as in the case of ember-changeset).
- Adds a test for this new code.
- Amends the readme with instructions on how to configure `errorsPath`.