### PR TITLE
Update ember-one-way-controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+### Changed
+- bumped `ember-one-way-controls` version to `^3.1.0` to remove deprecation warnings during builds
+
+
 ## [v1.11.0](https://github.com/shuriu/ember-do-forms/tree/v1.11.0) (2017-07-14)
 [Full Changelog](https://github.com/shuriu/ember-do-forms/compare/v1.10.0...v1.11.0)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.2",
     "ember-get-config": "^0.2.2",
-    "ember-one-way-controls": "^2.0.0"
+    "ember-one-way-controls": "^3.1.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
When building our app's on Ember 2.18, we were getting deprecation warnings from this addon because of it's dependency on `ember-one-way-controls@2.0.0` - this simply upgrades `ember-one-way-controls` to  `^3.1.0`

`ember t` fails just like on master

`ember t -s` passes just like on master

![image](https://user-images.githubusercontent.com/119129/48157322-86d1df00-e28c-11e8-90ad-493f1c472381.png)
